### PR TITLE
Fixed create quest order, added misc chapter, little fixes

### DIFF
--- a/config/ftbquests/quests/chapters/ad_astra.snbt
+++ b/config/ftbquests/quests/chapters/ad_astra.snbt
@@ -18,6 +18,7 @@
 			title: "Ad Astra!"
 			x: 0.0d
 			y: 0.0d
+			shape: "pentagon"
 			subtitle: "Space is the place for the human race"
 			description: ["It's time to escape to the one place untouched by capitalism.\\n\\nAd Astra adds a number of planets, accessible by building stronger and stronger rockets. Get ready to strip the solar system bare of its resources.\\n\\nYour first mission is to get to the moon."]
 			invisible: true

--- a/config/ftbquests/quests/chapters/applied_energistics.snbt
+++ b/config/ftbquests/quests/chapters/applied_energistics.snbt
@@ -19,14 +19,17 @@
 			title: "Getting even more organized"
 			x: 0.0d
 			y: -2.5d
+			shape: "pentagon"
 			subtitle: "Digitize me!"
 			description: ["AE2 is the ultimate storage and automation mod. Store items, fluids, import and export, autocraft, and much, much more. This mod has limitless potential, but things will be a little different than you remember..."]
 			dependencies: ["5D8A7258D40CAC95"]
 			hide: true
 			id: "36BC1A6A258712BB"
 			tasks: [{
-				id: "4025A67DC4E1D2BB"
-				type: "checkmark"
+				id: "741E71DBD5F51683"
+				type: "gamestage"
+				icon: "create:brass_encased_large_cogwheel"
+				stage: "Junior Engineer"
 			}]
 			rewards: [{
 				id: "5E6FAAF3714F2F7C"

--- a/config/ftbquests/quests/chapters/babbys_first_contraption.snbt
+++ b/config/ftbquests/quests/chapters/babbys_first_contraption.snbt
@@ -151,6 +151,7 @@
 			title: "Create begin"
 			x: -6.0d
 			y: -2.0d
+			shape: "pentagon"
 			subtitle: "The ungoogleable mod"
 			description: ["It is time to make things spin.\\n\\nCreate is a wild mod built around rotational power. It features plenty of low-tech machinery and all the cogs, gears, and belts you can handle.\\nThe centerpiece of the mod is the ability to make giant multiblock contraptions that actually move and spin, allowing for clever rube goldberg farms and rideable machines and trains."]
 			invisible: true

--- a/config/ftbquests/quests/chapters/botania.snbt
+++ b/config/ftbquests/quests/chapters/botania.snbt
@@ -41,6 +41,8 @@
 		{
 			x: -4.5d
 			y: 5.0d
+			subtitle: "Magic bird bath"
+			description: ["It makes new flowers!"]
 			dependencies: ["716255B06329D35E"]
 			hide: true
 			id: "4F9A7F938BFF6F02"
@@ -66,6 +68,7 @@
 		{
 			x: -3.0d
 			y: 5.5d
+			description: ["It turns stuff into more magic stuff!\\n\\nUsed to make Livingrock and Livingwood."]
 			dependencies: ["4F9A7F938BFF6F02"]
 			hide: true
 			size: 1.5d
@@ -84,6 +87,7 @@
 		{
 			x: -3.0d
 			y: 8.5d
+			subtitle: "Wood+"
 			dependencies: ["7C0209357D1AD3CC"]
 			hide: true
 			size: 1.5d
@@ -103,6 +107,7 @@
 		{
 			x: -3.0d
 			y: 3.5d
+			subtitle: "Rocks 2, the sequel to rocks"
 			dependencies: ["7C0209357D1AD3CC"]
 			hide: true
 			size: 1.5d
@@ -122,6 +127,8 @@
 		{
 			x: -2.5d
 			y: 2.0d
+			subtitle: "({T}: Add {G}.)"
+			description: ["It holds your mana! Point your mana spreaders at it to fill it.\\n\\nMana pools hold a comical amount of mana at a time. You might not see much of a difference until you leave your generating flora running for a while."]
 			dependencies: ["1E25DBB285BF3094"]
 			hide: true
 			size: 1.5d
@@ -161,6 +168,7 @@
 			x: -1.0d
 			y: 5.5d
 			subtitle: "Babby's first mana"
+			description: ["Endoflames are like a furnace, but also a flower. Drop solid fuel near one and it'll eat it up. \\n\\nThe classic automation trick for them is to pipe fuel into an open crate with a hopper, so the fuel lands on a pressure plate. Then, run some redstone from the plate to the hopper, and it'll only drop fuel when none remains on the pressure plate. That way, you never waste fuel."]
 			dependencies: ["452EE27DCD7A93FF"]
 			hide: true
 			id: "244323B38150C0AE"
@@ -205,6 +213,7 @@
 			x: 0.5d
 			y: 4.5d
 			subtitle: "Seriously, make this ASAP"
+			description: ["Give it mana, and it'll make more mystical flowers for you."]
 			dependencies: ["244323B38150C0AE"]
 			hide: true
 			id: "19CB64044BF4DCB1"
@@ -230,6 +239,8 @@
 		{
 			x: -0.5d
 			y: 2.5d
+			subtitle: "The cooler iron"
+			description: ["It's a useful metal! Throw iron into your mana pool to make it blue and cool."]
 			dependencies: ["4DA4CDC376DBA463"]
 			hide: true
 			id: "2709A0DD13D62CAB"
@@ -247,6 +258,8 @@
 		{
 			x: -4.5d
 			y: 1.5d
+			subtitle: "got any games on your mana rock"
+			description: ["It holds mana, but as an item. Use it to fuel your trinkets, or to easily move your mana pools without losing the precious blue juice."]
 			dependencies: ["4DA4CDC376DBA463"]
 			hide: true
 			id: "4359266C8F94CECC"
@@ -264,6 +277,7 @@
 		{
 			x: -6.0d
 			y: 0.0d
+			description: ["Holds mana for your trinkets, but without taking up an inventory slot."]
 			dependencies: ["4359266C8F94CECC"]
 			hide: true
 			id: "60F2C43E82F22349"
@@ -284,6 +298,7 @@
 			x: 1.5d
 			y: 1.5d
 			subtitle: "Yeah, I saw Cowboy Bebop once"
+			description: ["A little bit better than iron, and it enchants well. Plus, manasteel armor and tools will repair themselves with mana from your tablets and rings."]
 			dependencies: ["2709A0DD13D62CAB"]
 			hide: true
 			id: "0236CBA8BCA8C9BE"
@@ -342,6 +357,8 @@
 		{
 			x: -6.5d
 			y: -2.0d
+			subtitle: "Rune DMC"
+			description: ["Plenty of useful gear needs magic runes to work. Duh, it's magic, of course it needs runes.\\n\\nDrop rune components on it, wait for it to fill with mana, and then drop a livingrock on it and right click with your wand to finish the craft.\\nWhen making runes, runes in the recipe won't be consumed. Collect 'em all!"]
 			dependencies: ["4DA4CDC376DBA463"]
 			hide: true
 			id: "2F57AF46DB97D33A"
@@ -360,6 +377,8 @@
 		{
 			x: 2.0d
 			y: -1.5d
+			subtitle: "Terrasteel factory"
+			description: ["Oh hey, this thing needs a spark to function!\\n\\nThe terrestrial agglomeration plate (say it five times fast) makes terrasteel, an incredibly powerful metal. However, it takes half of a mana pool to make! Plan accordingly."]
 			dependencies: [
 				"67B7DE9690F5D811"
 				"6D7418B2E70BA199"
@@ -392,6 +411,7 @@
 		{
 			x: -1.5d
 			y: -3.5d
+			description: ["Expensive, but potent!"]
 			dependencies: ["37CB8552705CD277"]
 			hide: true
 			id: "27EFAC66FB06096A"
@@ -411,6 +431,8 @@
 			title: "Maximum Anime"
 			x: -3.5d
 			y: -2.5d
+			subtitle: "I have strong opinions re: subs vs dubs"
+			description: ["Wildly powerful armor. Wearing the full set grants you extra bonuses, like passive mana generation for your tools and trinkets. It's also sturdy as hell.\\n\\nIf you decide that being maximum anime is too much, Phantom Ink can be used to de-anime you."]
 			dependencies: [
 				"27EFAC66FB06096A"
 				"043B59326DA5F975"
@@ -436,6 +458,8 @@
 		{
 			x: 1.0d
 			y: 0.5d
+			subtitle: "Spooky action at a distance"
+			description: ["Sparks transfer mana from point to point. Some devices need one to function, and later you'll be able to set up networks of mana to move stuff around using these."]
 			dependencies: ["4DA4CDC376DBA463"]
 			id: "67B7DE9690F5D811"
 			tasks: [{
@@ -455,6 +479,7 @@
 			x: -4.0d
 			y: -1.0d
 			subtitle: "Let me show you my figurine collection"
+			description: ["Like manasteel armor, but better. It also comes with friends if you wear the full set."]
 			dependencies: ["221B37BA73D73FAB"]
 			hide: true
 			id: "2CF2049FA65E2DC0"
@@ -514,6 +539,8 @@
 			title: "Portal Time"
 			x: 0.5d
 			y: -1.0d
+			subtitle: "Alright, listen to me you knife-eared piece of shit!"
+			description: ["Time to give those elves an earful.\\n\\nFollow the book for the correct portal shape, but once active you can convert some ingredients into their fancy elf versions.\\n\\nDon't forget to toss your book in to get back a cooler book."]
 			dependencies: ["27EFAC66FB06096A"]
 			hide: true
 			id: "7F875ABD08CA1A43"
@@ -552,6 +579,8 @@
 		{
 			x: -2.5d
 			y: 0.5d
+			subtitle: "Elementium, my dear"
+			description: ["Basically the elven equivalent to manasteel. It is better than manasteel, but terrasteel outclasses it stats-wise. However, it is way easier to get!"]
 			dependencies: ["7F875ABD08CA1A43"]
 			hide: true
 			id: "221B37BA73D73FAB"
@@ -571,6 +600,7 @@
 			x: -1.0d
 			y: 0.5d
 			subtitle: "PEW PEW"
+			description: ["A way better mana spreader. It can send more mana at a time, so you need it if you intend to use the more powerful generating flora."]
 			dependencies: ["221B37BA73D73FAB"]
 			hide: true
 			id: "7C5C9E8675AC240B"
@@ -607,6 +637,8 @@
 		{
 			x: -3.0d
 			y: -3.5d
+			subtitle: "Magic moonshine"
+			description: ["The botanical brewery makes the usual complement of potions, plus some new unique potion types.\\n\\nThe real benefit here is that potions brewed here have multiple doses, so you can actually keep a stock of handy potions without filling your pockets.\\nAlso, later you can craft pendants here that grant you a potion effect passively."]
 			dependencies: ["6D7418B2E70BA199"]
 			hide: true
 			id: "346A2E672FF0F53E"
@@ -661,6 +693,7 @@
 		{
 			x: -2.0d
 			y: -5.0d
+			subtitle: "Magic symbol of magic"
 			dependencies: ["2F57AF46DB97D33A"]
 			hide: true
 			id: "6D7418B2E70BA199"
@@ -693,6 +726,7 @@
 			y: -1.0d
 			shape: "gear"
 			subtitle: "Buckle up for butt rock"
+			description: ["Let's kill a minor deity!\\n\\nThe ritual of gaia summons a powerful foe, but the rewards are well worth it. You will want to prepare heavily for the fight!"]
 			dependencies: [
 				"592BDEFE5089E05B"
 				"221B37BA73D73FAB"

--- a/config/ftbquests/quests/chapters/creating_creatively.snbt
+++ b/config/ftbquests/quests/chapters/creating_creatively.snbt
@@ -10,7 +10,7 @@
 	quests: [
 		{
 			title: "Moving Items"
-			x: -7.0d
+			x: -6.5d
 			y: -2.0d
 			subtitle: "Darn, I like the funnel"
 			description: ["Now that you have some rotational power, we can use that to move items around for early automation.\\nBelts move items on top of them and will generally move things onto depots, basins, or other belts, but to be able to move items in or out of most containers, you want a funnel.\\n\\nAlso worth noting-- belts are smart about not overflowing, and if you place some machinery on top of a belt (like the Mechanical Press), the items will wait for the machine to operate on it before continuing.\\n\\nAs always, Ponder these items for more thorough visual examples."]
@@ -27,11 +27,6 @@
 					type: "item"
 					item: "create:andesite_funnel"
 				}
-				{
-					id: "474EE08C1E60F834"
-					type: "item"
-					item: "create:chute"
-				}
 			]
 			rewards: [{
 				id: "6FB0FA931F36A1DA"
@@ -41,11 +36,11 @@
 		}
 		{
 			title: "Stressin'"
-			x: -5.5d
-			y: -0.5d
+			x: -6.5d
+			y: -3.5d
 			subtitle: "#relatable"
 			description: ["These two devices (which can be crafted into each other freely) measure the speed and stress placed on your mess of shafts and cogs.\\n\\nSources of rotational force, like the windmill and waterwheel, will set the stress capacity of your network, while machines like the press, mixer, and grindstone, will contribute stress to the network based on how fast they're spinning. Too much stress, and the whole thing grinds to a halt.\\n\\nUsing the stressometer and goggles, you can measure how each piece contributes. Don't forget that you can manually gear up or down using large and small cogs, to fine-tune how fast (and how stressful) a machine runs."]
-			dependencies: ["343CADE41B0F6A39"]
+			dependencies: ["5E7B0AFE76B9C023"]
 			id: "7BA51A9B269CB44B"
 			tasks: [
 				{
@@ -63,10 +58,10 @@
 		{
 			title: "Bearings"
 			x: -2.5d
-			y: -4.0d
+			y: -3.5d
 			subtitle: "Moving Parts"
 			description: ["Here's where the real magic starts!\\n\\nEach of these movement anchors allows you to turn rotational force into actual blocks moving in the world, in different ways.\\nCertain machines, like saws, drills, and plows, will function differently when on a moving contraption, allowing for powerful (and goofy) farms or digging machines!\\n\\n* Mechanical bearings rotate the attached blocks. Handy for making automatic farms!\\n* Mechanical Pistons will push (or pull) the attached structure. You must attach the extension poles to the back to set the length it works over.\\n* Rope pulleys will raise or lower the attached structure. Combine with a Gearshift to make a simple elevator!"]
-			dependencies: ["1076ED1CFD732BC8"]
+			dependencies: ["343CADE41B0F6A39"]
 			id: "418EE571FAC1ED00"
 			tasks: [
 				{
@@ -483,11 +478,11 @@
 			}]
 		}
 		{
-			x: -4.0d
-			y: -1.0d
+			x: -1.5d
+			y: -5.5d
 			subtitle: "Do not eat"
 			description: ["Superglue lets you stick multiple blocks together, so that when they are attached to a contraption (for example, the Windmill Bearing), they will move as a single unit.\\n\\nWhy not try making your windmill even fancier now that you can use more than just the sails?"]
-			dependencies: ["1076ED1CFD732BC8"]
+			dependencies: ["418EE571FAC1ED00"]
 			id: "326B958E0061BB59"
 			tasks: [{
 				id: "2552BC8CD340238C"
@@ -508,11 +503,11 @@
 		}
 		{
 			title: "Toolboxes"
-			x: -2.5d
-			y: 0.0d
+			x: -5.0d
+			y: -3.5d
 			subtitle: "Ol' Other Reliable"
 			description: ["Toolboxes are incredibly handy and absolutely worth making multiples of.\\nWhen placed, a toolbox has slots for 8 different items, and it keeps its contents when broken. Handy enough already, but if you hold down the hotkey while a toolbox is nearby, you can quickly swap between these items and keep them stocked on your hotbar! There's even a button to quickly return all items back to the toolbox.\\n\\nHere's some useful ideas for toolbox contents:\\n* Cogs, shafts, gearboxes, casings, and belts\\n* Pipes, wires, tubes\\n* Building blocks as an architect's palette\\n"]
-			dependencies: ["1076ED1CFD732BC8"]
+			dependencies: ["343CADE41B0F6A39"]
 			id: "4E64DA28958AED76"
 			tasks: [{
 				id: "15FB4A93E322F554"
@@ -526,8 +521,8 @@
 			}]
 		}
 		{
-			x: -5.5d
-			y: -3.5d
+			x: -4.0d
+			y: -4.0d
 			subtitle: "My brand!"
 			description: ["Wearing the goggles on your head (or head trinket slot) lets you see extra information about your contraptions, like the precise stress values from a Stressometer."]
 			dependencies: ["343CADE41B0F6A39"]
@@ -545,7 +540,7 @@
 		}
 		{
 			icon: "create:mechanical_press"
-			x: -5.5d
+			x: -4.0d
 			y: -2.0d
 			subtitle: "Impressive Machinery"
 			description: ["Our first machine that does something! The metal press makes plates. It needs a source of rotational power to work, so hook it up to a shaft.\\n\\nAdditionally, you'll need a depot underneath it. Create machines will often do their job on items placed onto a depot, basin, or belt."]
@@ -566,11 +561,11 @@
 			]
 		}
 		{
-			x: -1.5d
-			y: -3.5d
+			x: -5.0d
+			y: -0.5d
 			subtitle: "{2}, {T}: Target player mills two cards."
 			description: ["It grinds things into other things. Try putting wheat in to make flour!"]
-			dependencies: ["1076ED1CFD732BC8"]
+			dependencies: ["343CADE41B0F6A39"]
 			id: "1129D52F667A70ED"
 			tasks: [{
 				id: "50E5B86D90A00601"
@@ -585,11 +580,11 @@
 			}]
 		}
 		{
-			x: -0.5d
-			y: -2.5d
+			x: -4.0d
+			y: 0.0d
 			subtitle: "See?"
 			description: ["When stationary, it cuts stuff up, mostly wood. Turns logs into stripped logs, and stripped logs into planks. \\n\\nRight click the little yellow square to filter the item it will try to create (or use a fancy Filter item), otherwise it might not make what you expect.\\n\\nWhen on a moving contraption, it will halt the contraption and cut down trees!"]
-			dependencies: ["1076ED1CFD732BC8"]
+			dependencies: ["343CADE41B0F6A39"]
 			id: "54062BA0A124ECE9"
 			tasks: [{
 				id: "1A21EB7637AC224D"
@@ -605,11 +600,11 @@
 		}
 		{
 			icon: "create:mechanical_mixer"
-			x: -0.5d
-			y: -1.0d
+			x: -2.0d
+			y: -2.0d
 			subtitle: "A boxy blender"
 			description: ["When placed above a basin, it'll mix the stuff in the basin together!\\nIt needs to be running at a high enough speed or it won't do anything. Try using large cogs to gear up the speed!\\n\\nThere are several mixer-specific recipes, including ones involving fluids, but it can also automate crafting most shapeless recipes. Use the little yellow filter square to specify what to make."]
-			dependencies: ["1076ED1CFD732BC8"]
+			dependencies: ["343CADE41B0F6A39"]
 			id: "55D2B8E90BD9FE28"
 			tasks: [
 				{
@@ -652,11 +647,11 @@
 		}
 		{
 			title: "Pipes"
-			x: -0.5d
-			y: 0.5d
+			x: -2.0d
+			y: -0.5d
 			subtitle: "Better than the screensaver"
 			description: ["Create pipes are a little funky, but offer a low-power way to move fluids around.\\n\\nPumps are required to move things from one tank to another, and have a limited range. Right click a pipe with a wrench to make a window so you can see what you're doing.\\nNotably, a pipe with a pump can extract fluid from the world if placed against source blocks. Great for getting water in."]
-			dependencies: ["1076ED1CFD732BC8"]
+			dependencies: ["343CADE41B0F6A39"]
 			id: "5FC1EE27344EB819"
 			tasks: [
 				{
@@ -688,8 +683,8 @@
 		}
 		{
 			icon: "create:hose_pulley"
-			x: -0.5d
-			y: 1.5d
+			x: -2.0d
+			y: 1.0d
 			subtitle: "The biggest straw"
 			description: ["A hose pulley will suck up fluids from the world. Most importantly, if it's draining a large enough body of water, it treats it as infinite. Try pumping lava from the Nether!\\nThe hose needs to be lowered into the fluid before it can work. Use a valve and manually crank it to get it in the drink."]
 			dependencies: ["5FC1EE27344EB819"]
@@ -713,7 +708,7 @@
 			}]
 		}
 		{
-			x: 1.0d
+			x: 0.5d
 			y: 0.5d
 			subtitle: "I hope it was worth the wait."
 			description: ["Steam boilers are a beefy source of rotational power, provided you can meet their demands!\\nPonder the steam engine for more details, but the general idea is you put a heat source below copper tanks filled with water. If the conditions are right it will start to actuate the piston on the steam engine!\\n\\nA simple boiler setup is four campfires under a 2x2x2 cube of tanks, which is receiving a steady supply of water. This can be scaled up with a bigger tank, more steam engines, and well-fed blaze burners.\\nTry setting up a factory that produces blaze cakes for a potent heat source for massive power!"]
@@ -735,11 +730,12 @@
 		}
 		{
 			title: "Blaze Burner"
-			x: 1.0d
+			x: 0.5d
 			y: -1.0d
 			subtitle: "Help wanted"
 			description: ["Our mixer works pretty well, but it could use a little more oomph. Why not hire some of the locals to heat things up?\\nMake an empty blaze burner, then take it to the Nether. Either find a Blaze or a Blaze Spawner, and use the burner on it to make it a job offer.\\n\\nWhen placed below a mixer's basin, you can provide the burner solid fuel like coal to temporarily heat it and enable new and exciting recipes."]
 			dependencies: ["55D2B8E90BD9FE28"]
+			size: 1.5d
 			id: "1DA6287751314C5F"
 			tasks: [
 				{
@@ -805,7 +801,7 @@
 		}
 		{
 			title: "Mechanical Crafting"
-			x: 2.5d
+			x: 2.0d
 			y: -2.5d
 			subtitle: "AI stealing our jobs!"
 			description: ["Mechanical crafters are used to craft things automatically. Definitely one to Ponder!\\nEach crafter represents one square in a shaped crafting recipe, and can be used in recipes involving more than the normal number of ingredients.\\n\\nTroubleshooting tips:\\n* Make sure each crafter leads to the other crafters. You can think of them as combining the item they hold with the one(s) next in line. The final crafter can lead to a belt, chest, etc.\\n* Items can be automatically inserted into a crafter. You can also right click the back with a wrench to join adjacent crafters together-- this means items inserted into one will also flow into the other joined crafters. Useful for repeated ingredients.\\n* You can use covers in case a recipe has gaps, but you still want a crafter there.\\n* Crafting is stressful! You may want to gear these down."]
@@ -863,7 +859,7 @@
 			}]
 		}
 		{
-			x: 4.0d
+			x: 4.5d
 			y: 0.0d
 			subtitle: "Pass me that spanner"
 			description: ["Mechanical arms are tricky, but powerful.\\nBefore you place one, you define the inputs and outputs. Then as long as it is powered, it will attempt to move items from the inputs to the outputs. Funnels work great for both of these, and output funnels can be filtered to route items correctly.\\n\\nArms are most useful when stocking a bank of mechanical crafters, or when you need to move items across the room without a cumbersome conveyor belt."]
@@ -908,7 +904,7 @@
 			}]
 		}
 		{
-			x: 4.0d
+			x: 4.5d
 			y: -2.0d
 			subtitle: "Cheat to win"
 			description: ["Mathing out gear ratios is for nerds. With the rotation speed controller, you can set the speed directly! Goes great with a stressometer to set the precise max speed your workshop can run at."]
@@ -1049,15 +1045,11 @@
 			}]
 		}
 		{
-			x: -2.5d
-			y: -2.0d
+			x: 3.0d
+			y: -2.5d
 			subtitle: "The glorious Fing-Longer"
 			description: ["The deployer is a crucial piece of automation, both for production challenges as well as interacting with the world.\\n\\nYou can grab milk, harvest berries, and so much more!\\n\\nFrom this point, the possibilities become endless. Time to branch out and learn!"]
-			dependencies: [
-				"343CADE41B0F6A39"
-				"343CADE41B0F6A39"
-			]
-			size: 1.8d
+			dependencies: ["3F86E4742F44DF54"]
 			id: "1076ED1CFD732BC8"
 			tasks: [{
 				id: "690DD3B8F1847ED4"
@@ -1095,8 +1087,9 @@
 			}]
 		}
 		{
-			x: -8.5d
+			x: -8.0d
 			y: -2.0d
+			shape: "pentagon"
 			subtitle: "Babby's Second Contraption"
 			description: ["Ready to start making some serious Rube Goldberg machines?\\nLet's begin."]
 			dependencies: ["5D8A7258D40CAC95"]
@@ -1112,7 +1105,7 @@
 		}
 		{
 			icon: "indrev:enriched_nikolite_dust"
-			x: 1.0d
+			x: 0.5d
 			y: -2.5d
 			shape: "octagon"
 			subtitle: "The Technology Age"
@@ -1156,16 +1149,30 @@
 			}]
 		}
 		{
-			x: -4.0d
-			y: -3.0d
-			subtitle: "Just in case you forgot already"
-			dependencies: ["1076ED1CFD732BC8"]
-			id: "1FE96F6E7681A78E"
+			x: -3.5d
+			y: -5.5d
+			subtitle: "Farm and factory, sitting in a tree...!"
+			description: ["In order to get stuff out of moving contraptions like an automatic farm, you need a storage interface on the contraption, and another stationary interface on the ground for it to pass items to.\\n\\nMake sure there's a single block between the two, and it'll pause the contraption to send items over.\\nDon't forget, you need to extract the items from the interface somehow!"]
+			dependencies: ["418EE571FAC1ED00"]
+			id: "3958DE3879C70E85"
 			tasks: [{
-				id: "6B008478313596A8"
+				id: "032610B9ADFCFD97"
 				type: "item"
-				item: "create:wrench"
+				item: "create:portable_storage_interface"
+				count: 2L
 			}]
+			rewards: [
+				{
+					id: "6E027F74AD1BD73E"
+					type: "xp_levels"
+					xp_levels: 1
+				}
+				{
+					id: "03EB2E45117421BE"
+					type: "item"
+					item: "create:andesite_funnel"
+				}
+			]
 		}
 	]
 	quest_links: [ ]

--- a/config/ftbquests/quests/chapters/creating_creatively.snbt
+++ b/config/ftbquests/quests/chapters/creating_creatively.snbt
@@ -36,11 +36,11 @@
 		}
 		{
 			title: "Stressin'"
-			x: -6.5d
-			y: -3.5d
+			x: -5.0d
+			y: -4.0d
 			subtitle: "#relatable"
 			description: ["These two devices (which can be crafted into each other freely) measure the speed and stress placed on your mess of shafts and cogs.\\n\\nSources of rotational force, like the windmill and waterwheel, will set the stress capacity of your network, while machines like the press, mixer, and grindstone, will contribute stress to the network based on how fast they're spinning. Too much stress, and the whole thing grinds to a halt.\\n\\nUsing the stressometer and goggles, you can measure how each piece contributes. Don't forget that you can manually gear up or down using large and small cogs, to fine-tune how fast (and how stressful) a machine runs."]
-			dependencies: ["5E7B0AFE76B9C023"]
+			dependencies: ["343CADE41B0F6A39"]
 			id: "7BA51A9B269CB44B"
 			tasks: [
 				{
@@ -138,7 +138,7 @@
 			x: -4.0d
 			y: -9.5d
 			subtitle: "All the trees and wheat"
-			description: ["Using a mechanical bearing (or a windmill bearing!), one can make an automatic circular farm.\\n\\nAttach chassis blocks to the bearing to make an arm, and attach the saws (for trees) or ploughs (for crops) to the leading edge of one arm. These will harvest the crops or chop the trees.\\nThen to the back side of the arm, attach deployers to replant the saplings or crops.\\n\\nAttach a barrel (or other container) to the whole structure, and it will place the harvested blocks in it, and use stored items to replant.\\nThen, attach a portable storage interface somewhere to the structure. When it passes another storage interface, it will stop and try to deposit items into it, letting you get items out of the contraption. \\n\\nDefinitely Ponder the storage interface, it can be finnicky!"]
+			description: ["Using a mechanical bearing (or a windmill bearing!), one can make an automatic circular farm.\\n\\nAttach chassis blocks to the bearing to make an arm, and attach the saws (for trees) or harvesters (for crops) to the leading edge of one arm. These will harvest the crops or chop the trees.\\nThen to the back side of the arm, attach deployers to replant the saplings. For crops, the harvester is smart enough to replant crops on its own.\\n\\nAttach a barrel (or other container) to the whole structure, and it will place the harvested blocks in it, and use stored items to replant.\\nThen, attach a portable storage interface somewhere to the structure. When it passes another storage interface, it will stop and try to deposit items into it, letting you get items out of the contraption. \\n\\nDefinitely Ponder the storage interface, it can be finnicky!"]
 			dependencies: ["4E955863939B3974"]
 			id: "788D4EF3F7C90645"
 			tasks: [
@@ -150,7 +150,7 @@
 				{
 					id: "03FF07005C3D7C9C"
 					type: "item"
-					item: "create:mechanical_plough"
+					item: "create:mechanical_harvester"
 				}
 				{
 					id: "78085FEE9E67E883"
@@ -503,8 +503,8 @@
 		}
 		{
 			title: "Toolboxes"
-			x: -5.0d
-			y: -3.5d
+			x: -5.5d
+			y: -3.0d
 			subtitle: "Ol' Other Reliable"
 			description: ["Toolboxes are incredibly handy and absolutely worth making multiples of.\\nWhen placed, a toolbox has slots for 8 different items, and it keeps its contents when broken. Handy enough already, but if you hold down the hotkey while a toolbox is nearby, you can quickly swap between these items and keep them stocked on your hotbar! There's even a button to quickly return all items back to the toolbox.\\n\\nHere's some useful ideas for toolbox contents:\\n* Cogs, shafts, gearboxes, casings, and belts\\n* Pipes, wires, tubes\\n* Building blocks as an architect's palette\\n"]
 			dependencies: ["343CADE41B0F6A39"]
@@ -634,14 +634,6 @@
 					type: "item"
 					item: "minecraft:acacia_leaves"
 					count: 16
-				}
-				{
-					id: "1919A2E552525B6D"
-					type: "gamestage"
-					icon: "ad_astra:earth_globe"
-					auto: "invisible"
-					ignore_reward_blocking: true
-					stage: "Ad Astra Ready"
 				}
 			]
 		}

--- a/config/ftbquests/quests/chapters/getting_food.snbt
+++ b/config/ftbquests/quests/chapters/getting_food.snbt
@@ -232,35 +232,41 @@
 			description: ["Hold more food."]
 			dependencies: ["41123F8C9183CF26"]
 			id: "57A75FA244CBFD3C"
-			tasks: [
-				{
-					id: "17039B460D9EAB11"
-					type: "item"
-					item: {
-						id: "spiceoffabric:picnic_basket"
-						Count: 1b
-						tag: {
-							inventory: { }
-						}
+			tasks: [{
+				id: "15D6A4369F3BC557"
+				type: "item"
+				item: {
+					id: "spiceoffabric:lunch_box"
+					Count: 1b
+					tag: {
+						inventory: { }
 					}
 				}
-				{
-					id: "15D6A4369F3BC557"
-					type: "item"
-					item: {
-						id: "spiceoffabric:lunch_box"
-						Count: 1b
-						tag: {
-							inventory: { }
-						}
-					}
-				}
-			]
+			}]
 			rewards: [{
 				id: "5B30930C75DB27A8"
 				type: "item"
 				item: "croptopia:coffee_seed"
 				count: 4
+			}]
+		}
+		{
+			x: 3.0d
+			y: 3.5d
+			subtitle: "ACME Seal of Quality"
+			description: ["This will slowly fill up with milk over time, and if you place it in your kitchen, it'll provide milk to recipes.\\n\\nMaking it is as looney tunes as possible-- place down a jar, coax a cow to stand on that jar, and then drop an anvil on it."]
+			dependencies: ["3F7BDCE7A4B2A996"]
+			id: "3C972D2C04F0222F"
+			tasks: [{
+				id: "6D6258FD6952B188"
+				type: "item"
+				item: "cookingforblockheads:cow_jar"
+			}]
+			rewards: [{
+				id: "4D3B9DCBE5163404"
+				type: "item"
+				item: "minecraft:glass_bottle"
+				count: 3
 			}]
 		}
 	]

--- a/config/ftbquests/quests/chapters/industrial_revolution.snbt
+++ b/config/ftbquests/quests/chapters/industrial_revolution.snbt
@@ -697,8 +697,8 @@
 				Count: 1b
 				tag: {
 					selected: { }
-					energy: 10000L
 					Progress: 1.0f
+					energy: 10000L
 					Damage: 0
 					Active: 1b
 				}
@@ -724,8 +724,8 @@
 					Count: 1b
 					tag: {
 						selected: { }
-						energy: 10000L
 						Progress: 1.0f
+						energy: 10000L
 						Damage: 0
 						Active: 1b
 					}
@@ -767,6 +767,7 @@
 			icon: "powah:energizing_rod_starter"
 			x: 3.0d
 			y: 1.5d
+			shape: "octagon"
 			subtitle: "Zap"
 			description: ["Now that you have somewhere to put your energy, you're going to need to generate some."]
 			dependencies: ["77DE5B902EE8B34B"]

--- a/config/ftbquests/quests/chapters/industrial_revolution.snbt
+++ b/config/ftbquests/quests/chapters/industrial_revolution.snbt
@@ -12,6 +12,7 @@
 			title: "Technology"
 			x: -1.5d
 			y: 0.0d
+			shape: "pentagon"
 			subtitle: "Oh my god, it's all blocks"
 			description: ["Industrial Revolution (or Indrev) is a sort of 'greatest hits' of tech mods. It's a workhorse mod full of familiar metal boxes that turn stuff into other stuff, as well as providing power armor, tools, mining machines, and ore processing.\\n\\nIn this pack, Indrev is gated behind Create and Ad Astra. Make sure you have a well-furnished workshop first, and can fetch resources from other planets!"]
 			hide: true
@@ -553,7 +554,7 @@
 			y: -1.5d
 			shape: "rsquare"
 			description: ["By smelting our ores into a liquid first, then solidifying them with a condenser, we can get purer ores, resulting in more yields per ore."]
-			dependencies: ["4728A77657E316B3"]
+			dependencies: ["26944300C176F181"]
 			hide: true
 			id: "4249C0B59801E66F"
 			tasks: [
@@ -696,8 +697,8 @@
 				Count: 1b
 				tag: {
 					selected: { }
-					Progress: 1.0f
 					energy: 10000L
+					Progress: 1.0f
 					Damage: 0
 					Active: 1b
 				}
@@ -723,8 +724,8 @@
 					Count: 1b
 					tag: {
 						selected: { }
-						Progress: 1.0f
 						energy: 10000L
+						Progress: 1.0f
 						Damage: 0
 						Active: 1b
 					}
@@ -738,7 +739,7 @@
 			title: "A Special Offer"
 			x: 3.0d
 			y: -1.5d
-			shape: "pentagon"
+			shape: "diamond"
 			subtitle: "Seems like a bad idea"
 			description: ["Psst... Hey kid! Yeah, you!\\n\\nYou wanna fly? I bet you do, kid. I bet you do.\\nYou didn't hear it from me, but this thing'll take you way up high!\\n\\nJust uh, make sure you got your landing sorted out first, eh? Wouldn't want you to have an accident or nothin'."]
 			dependencies: ["77DE5B902EE8B34B"]

--- a/config/ftbquests/quests/chapters/mastery.snbt
+++ b/config/ftbquests/quests/chapters/mastery.snbt
@@ -159,8 +159,8 @@
 					Count: 1b
 					tag: {
 						selected: { }
-						energy: 10000L
 						Progress: 1.0f
+						energy: 10000L
 						Damage: 0
 						Active: 1b
 					}
@@ -174,8 +174,8 @@
 				Count: 1b
 				tag: {
 					selected: { }
-					Progress: 1.0f
 					energy: 10000L
+					Progress: 1.0f
 					Damage: 0
 					Active: 1b
 				}
@@ -195,8 +195,8 @@
 						Count: 1b
 						tag: {
 							selected: { }
-							energy: 10000L
 							Progress: 1.0f
+							energy: 10000L
 							Damage: 0
 							Active: 1b
 						}

--- a/config/ftbquests/quests/chapters/mastery.snbt
+++ b/config/ftbquests/quests/chapters/mastery.snbt
@@ -87,7 +87,7 @@
 				id: "717BB155562DDB1D"
 				type: "item"
 				item: "botania:life_essence"
-				count: 512L
+				count: 256L
 				consume_items: true
 			}]
 			rewards: [{
@@ -159,8 +159,8 @@
 					Count: 1b
 					tag: {
 						selected: { }
-						Progress: 1.0f
 						energy: 10000L
+						Progress: 1.0f
 						Damage: 0
 						Active: 1b
 					}
@@ -174,8 +174,8 @@
 				Count: 1b
 				tag: {
 					selected: { }
-					energy: 10000L
 					Progress: 1.0f
+					energy: 10000L
 					Damage: 0
 					Active: 1b
 				}
@@ -195,8 +195,8 @@
 						Count: 1b
 						tag: {
 							selected: { }
-							Progress: 1.0f
 							energy: 10000L
+							Progress: 1.0f
 							Damage: 0
 							Active: 1b
 						}
@@ -322,7 +322,7 @@
 				id: "4A35834352011DCC"
 				type: "item"
 				item: "ae2:cell_component_256k"
-				count: 256L
+				count: 128L
 				consume_items: true
 			}]
 			rewards: [{

--- a/config/ftbquests/quests/chapters/personal_storage.snbt
+++ b/config/ftbquests/quests/chapters/personal_storage.snbt
@@ -11,6 +11,7 @@
 		{
 			x: 0.0d
 			y: 0.0d
+			shape: "pentagon"
 			invisible: true
 			id: "2E53306C3198EB5E"
 			tasks: [{

--- a/config/ftbquests/quests/chapters/powah.snbt
+++ b/config/ftbquests/quests/chapters/powah.snbt
@@ -81,6 +81,7 @@
 			x: 3.0d
 			y: 0.0d
 			subtitle: "Renewable energy"
+			description: ["\"But I don't want to pillage the earth for natural resources, and ruin the atmosphere forever!\" I hear you cry. \"Renewable energy is the future!\"\\n\\nAbsolutely baffling, and definitely not in the Shitsco Inc. spirit. But I guess there's some merit to turning your excess crops into biofuel for renewable power."]
 			dependencies: ["683E2DFF8C1ED379"]
 			id: "380DE426FD46AE6D"
 			tasks: [{
@@ -88,11 +89,18 @@
 				type: "item"
 				item: "indrev:biomass"
 			}]
+			rewards: [{
+				id: "39360F93FDBE18B2"
+				type: "item"
+				item: "minecraft:bone_meal"
+				count: 8
+			}]
 		}
 		{
 			x: 4.0d
 			y: 1.5d
 			subtitle: "Burn it in a furnace, or for power!"
+			description: ["Biomass pellets are a good replacement for coal in a furnace, or other solid-fuel generator. \\n\\nIt also tastes great to blazes-- you could reasonably feed a blaze burner with this!"]
 			dependencies: ["380DE426FD46AE6D"]
 			id: "57E219BC2A112CE6"
 			tasks: [{
@@ -100,29 +108,25 @@
 				type: "item"
 				item: "createaddition:biomass_pellet"
 			}]
+			rewards: [{
+				id: "429FB0C5E0ACD94B"
+				type: "item"
+				item: "indrev:biomass"
+				count: 4
+			}]
 		}
 		{
 			x: 3.0d
-			y: 1.5d
+			y: 2.5d
 			subtitle: "Liquid fuel"
+			description: ["Biomass can be juiced into a nice base for rocket fuel production. It's not as efficient as processing sweet Texas tea, but it's completely renewable."]
 			dependencies: ["380DE426FD46AE6D"]
+			size: 1.25d
 			id: "787AD553244F730C"
 			tasks: [{
 				id: "69E8408B8133003C"
 				type: "item"
 				item: "kubejs:biofuel_bucket"
-			}]
-		}
-		{
-			x: 3.0d
-			y: 3.0d
-			subtitle: "Rocket fuel!"
-			dependencies: ["787AD553244F730C"]
-			id: "7261C5CC8DBB35E8"
-			tasks: [{
-				id: "26D8E7630E38D480"
-				type: "item"
-				item: "ad_astra:fuel_bucket"
 			}]
 		}
 		{
@@ -191,12 +195,19 @@
 			x: 2.0d
 			y: 1.5d
 			subtitle: "This is what they call greenwashing"
+			description: ["Take your coward fuel and burn it in here! The biomass generator burns biomass to generate energy."]
 			dependencies: ["380DE426FD46AE6D"]
 			id: "465701F2AD463E12"
 			tasks: [{
 				id: "5C61352CAE8C8232"
 				type: "item"
 				item: "indrev:biomass_generator_mk3"
+			}]
+			rewards: [{
+				id: "6E9C70E0ADF2BF34"
+				type: "item"
+				item: "indrev:biomass"
+				count: 8
 			}]
 		}
 		{

--- a/config/ftbquests/quests/chapters/powah.snbt
+++ b/config/ftbquests/quests/chapters/powah.snbt
@@ -11,6 +11,7 @@
 		{
 			x: -0.5d
 			y: 0.0d
+			shape: "pentagon"
 			description: ["Powah! It does what it says on the tin: make power, and a lot of it! Each generator can be upgraded multiple times, increasing power yields each time. But, be aware that higher tier materials will need plenty of power to even make."]
 			hide: true
 			invisible: true

--- a/config/ftbquests/quests/chapters/shame_corner.snbt
+++ b/config/ftbquests/quests/chapters/shame_corner.snbt
@@ -47,7 +47,7 @@
 				type: "stat"
 				icon: "spectrum:seven_league_boots"
 				stat: "minecraft:walk_one_cm"
-				value: 804672
+				value: 80467200
 			}]
 			rewards: [{
 				id: "1D37D5760ECC353E"
@@ -60,7 +60,9 @@
 			x: 2.0d
 			y: 1.0d
 			subtitle: "Those are rookie numbers!"
+			description: ["C'mon, are you even trying?!"]
 			dependencies: ["406287A073655976"]
+			optional: true
 			id: "44626C05C3AA1968"
 			tasks: [{
 				id: "792BA7000D67A549"
@@ -205,6 +207,25 @@
 				id: "1D24BF5304FFC567"
 				type: "xp_levels"
 				xp_levels: 5
+			}]
+		}
+		{
+			x: 0.0d
+			y: 2.0d
+			subtitle: "You're a real professional!"
+			description: ["I don't want to know how or why you arrived at this, but Shitsco Inc. salutes you."]
+			dependencies: ["7B8AB9B7B4652955"]
+			invisible: true
+			id: "66A7257172402F90"
+			tasks: [{
+				id: "412C0CB90F7E9C3A"
+				type: "item"
+				item: "reaping:human_meat"
+			}]
+			rewards: [{
+				id: "2A337B76362E8127"
+				type: "item"
+				item: "farmersdelight:milk_bottle"
 			}]
 		}
 	]

--- a/config/ftbquests/quests/chapters/spectrum.snbt
+++ b/config/ftbquests/quests/chapters/spectrum.snbt
@@ -78,8 +78,8 @@
 			]
 		}
 		{
-			x: 2.0d
-			y: -2.0d
+			x: 1.0d
+			y: -0.5d
 			description: [
 				"Don't feel like you need to rush this one. There are a few neat things you can craft before this point. You'll need to upgrade (and then open) your pigment pedestal and locate some newly-revealed ore to progress, however."
 				""
@@ -111,8 +111,8 @@
 		}
 		{
 			icon: "minecraft:oak_leaves"
-			x: 4.0d
-			y: -2.0d
+			x: 2.0d
+			y: -3.5d
 			description: [
 				"Your book tells you that you're ready to start creating life but only gives you cryptic hints about things that are \"easy to digest\". What could that mean, I wonder?"
 				""
@@ -133,8 +133,8 @@
 			}]
 		}
 		{
-			x: 6.0d
-			y: -2.0d
+			x: 3.0d
+			y: -1.0d
 			dependencies: ["76DC065DC1E3776A"]
 			id: "4576192D1AC284CE"
 			tasks: [{
@@ -145,14 +145,13 @@
 			}]
 		}
 		{
-			x: 8.0d
-			y: -2.0d
+			x: 4.0d
+			y: -2.5d
 			description: [
 				"You may have realized that a few colored saplings were uncraftable. Once you're done playing with your glistering melon seeds and all the other stuff you unlocked, this quest remedies that and more."
 				""
 				"Plonk down a complete fusion shrine then make some onyx. You'll need a lot of this."
 				""
-				"Sorry about the whole \"only at midnight on a new moon\" thing."
 			]
 			dependencies: ["4576192D1AC284CE"]
 			id: "2263B1680960E026"
@@ -178,8 +177,8 @@
 			}]
 		}
 		{
-			x: 10.0d
-			y: -2.0d
+			x: 5.0d
+			y: 0.0d
 			dependencies: ["2263B1680960E026"]
 			id: "4F9AEC0AFE940496"
 			tasks: [{
@@ -202,8 +201,8 @@
 			}]
 		}
 		{
-			x: 12.0d
-			y: -2.0d
+			x: 6.0d
+			y: -4.0d
 			description: ["Poke around in the Nether, sailing around an ocean, or tooling around in swamps for three brand new resources that have been revealed to you."]
 			dependencies: ["4F9AEC0AFE940496"]
 			id: "35807A7204025C2A"
@@ -231,12 +230,12 @@
 		{
 			title: "Spectrum Mastered"
 			icon: "spectrum:paintbrush"
-			x: 15.0d
+			x: 9.0d
 			y: -2.0d
 			shape: "gear"
 			subtitle: "Is that everything?"
 			description: ["Not really, but close enough."]
-			dependencies: ["35807A7204025C2A"]
+			dependencies: ["210C14FC4ECFC2FA"]
 			size: 2.0d
 			id: "7431697C688A81E9"
 			tasks: [{
@@ -250,6 +249,19 @@
 				auto: "invisible"
 				ignore_reward_blocking: true
 				stage: "Spectrum Mastered"
+			}]
+		}
+		{
+			x: 7.0d
+			y: -1.0d
+			description: ["Before we can grant you the rank of master, you'll need to find a way to do the impossible-- break the very bedrock underpinning this world."]
+			dependencies: ["35807A7204025C2A"]
+			id: "210C14FC4ECFC2FA"
+			tasks: [{
+				id: "240E25F0E4B1E4FD"
+				type: "advancement"
+				advancement: "spectrum:midgame/break_decayed_bedrock"
+				criterion: ""
 			}]
 		}
 	]

--- a/config/ftbquests/quests/chapters/thriving.snbt
+++ b/config/ftbquests/quests/chapters/thriving.snbt
@@ -1,0 +1,825 @@
+{
+	id: "2DD6D7BAB2232420"
+	group: "1EA615118F0BB9C5"
+	order_index: 1
+	filename: "thriving"
+	title: "Thriving"
+	icon: "minecraft:golden_horse_armor"
+	default_quest_shape: ""
+	default_hide_dependency_lines: false
+	quests: [
+		{
+			title: "Thriving"
+			icon: "create:cogwheel"
+			x: 0.0d
+			y: 0.0d
+			shape: "pentagon"
+			subtitle: "Remember the Shitsco motto: \"Whole ass, never half.\""
+			description: ["Shitsco Inc. invites you to live it up.\\n\\nGone are the days of scrabbling for basic resources, breaking your blocky fingers to eke out a living.\\n\\nIn this chapter, we'll highlight some miscellaneous things you have access to, in order to make your (likely short) life better."]
+			id: "2BF52FBBC4A3321E"
+			tasks: [{
+				id: "1653F4087D0B5103"
+				type: "gamestage"
+				icon: "create:cogwheel"
+				stage: "Intern"
+			}]
+			rewards: [{
+				id: "62B784A9766F9750"
+				type: "item"
+				item: "croptopia:beer"
+			}]
+		}
+		{
+			x: -3.0d
+			y: 1.5d
+			subtitle: "Black Market Box"
+			description: ["Nether chests behave like the ender chest you might be familiar with. However, instead of just belonging to you, the contents are shared with the entire world!\\n\\nUse it to arrange backroom deals, send letter bombs to your friends, or leave joke items for others to shake their heads at."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "1545F0B5CAE339F6"
+			tasks: [{
+				id: "51E3C3057E442CB8"
+				type: "item"
+				item: "netherchest:nether_chest"
+			}]
+			rewards: [{
+				id: "5291BC0843474C3E"
+				type: "xp_levels"
+				xp_levels: 3
+			}]
+		}
+		{
+			title: "The Mining Dimension"
+			icon: "mining_dims:mining_portal_block"
+			x: -2.0d
+			y: -2.0d
+			subtitle: "Gonna take your pick to another dimension"
+			description: ["The mining dimension is a world with only rolling hills and deserts, where it's always sunny.\\n\\nOf course, such a pristine paradise is made to be despoiled-- feel free to strip mine the earth here.\\n\\nIt's formed just like a nether portal, but lit with the Portal Lighter."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "0CFFCB07AB830565"
+			tasks: [
+				{
+					id: "216D433DBCC0E415"
+					type: "item"
+					item: "mining_dims:mining_portal_block"
+					count: 10L
+				}
+				{
+					id: "6484EDF55579E9B8"
+					type: "item"
+					item: "mining_dims:flint_and_diamond"
+				}
+			]
+			rewards: [{
+				id: "19D78CCED4C707BD"
+				type: "item"
+				item: "minecraft:torch"
+				count: 16
+			}]
+		}
+		{
+			title: "The Nethering Dimension"
+			icon: "mining_dims:nethering_portal_block"
+			x: -2.0d
+			y: -3.0d
+			subtitle: "Actually, is your grandpa's hell"
+			description: ["The nethering dimension looks... familiar. \\nInside is another nether, but without any of the fancy extras that make finding fortresses difficult.\\n\\nIt's formed just like a nether portal, but lit with the Portal Lighter."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "4C257327ED8F06A4"
+			tasks: [
+				{
+					id: "1E93D10716A581B9"
+					type: "item"
+					item: "mining_dims:nethering_portal_block"
+					count: 10L
+				}
+				{
+					id: "25E7B0380FDC72BD"
+					type: "item"
+					item: "mining_dims:flint_and_diamond"
+				}
+			]
+			rewards: [{
+				id: "2176A3D3E08C45C1"
+				type: "item"
+				item: {
+					id: "minecraft:lingering_potion"
+					Count: 1b
+					tag: {
+						Potion: "minecraft:fire_resistance"
+					}
+				}
+			}]
+		}
+		{
+			title: "Shields"
+			x: 2.0d
+			y: -1.0d
+			subtitle: "Skellie-B-Gone"
+			description: ["Seriously, make a dang shield!\\n\\nSkeletons are brutal on higher difficulties, but a shield goes a long way to making them easier to handle."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "46FC452008BB7046"
+			tasks: [{
+				id: "1942E0EBB022ACD0"
+				type: "item"
+				title: "Any Shield"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "minecraft:shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "basicshields:wooden_shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "basicshields:golden_shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "basicshields:diamond_shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "basicshields:netherite_shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "basicshields:bronze_shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "basicshields:steel_shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "twilightforest:knightmetal_shield"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "042BCA3604DDC863"
+				type: "item"
+				item: "minecraft:bone"
+			}]
+		}
+		{
+			title: "Sleeping Bags"
+			x: 2.0d
+			y: 2.5d
+			subtitle: "show yourself, coward. i will never log off"
+			description: ["Sleeping bags are a portable bed. Handy when the rest of the world is begging you to go to bed, but you're miles from home."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "32BC21DD01350538"
+			tasks: [{
+				id: "21D2581F49C0BBB2"
+				type: "item"
+				item: "comforts:sleeping_bag_white"
+			}]
+			rewards: [{
+				id: "721F9C1B67D46132"
+				type: "item"
+				item: "croptopia:tea"
+			}]
+		}
+		{
+			x: -1.0d
+			y: 1.5d
+			subtitle: "Extra nice!"
+			description: ["Besides being tasty, rice also has some useful byproducts.\\nIf you've found rice from Farmer's Delight, you can plant it in water and grow more. After harvesting, you'll have rice panicles.\\n\\nBy using a cutting board and knife, you can get rice, as well as straw, which can be used to make canvas, which replaces leather in some recipes. "]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "0AD571F768A70D75"
+			tasks: [{
+				id: "7C9A6DF36AD7C7C9"
+				type: "item"
+				item: "farmersdelight:rice"
+			}]
+			rewards: [{
+				id: "0D1A1C855908010E"
+				type: "item"
+				item: "farmersdelight:straw"
+				count: 4
+			}]
+		}
+		{
+			title: "Waystones"
+			x: -2.0d
+			y: -1.0d
+			subtitle: "Return ticket not included"
+			description: ["Waystones allow travel to any previously discovered waystone in exchange for some XP levels.\\n\\nIf you make and place a waystone, on the second tab you can click the little globe to make it automatically available to all other players!"]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "37754BBD5D767FA1"
+			tasks: [{
+				id: "68459A3885F692DB"
+				type: "item"
+				item: "fwaystones:waystone"
+			}]
+			rewards: [{
+				id: "5D11DC64D3E57AF9"
+				type: "xp_levels"
+				xp_levels: 8
+			}]
+		}
+		{
+			title: "Magnum Torches"
+			x: 2.0d
+			y: -3.0d
+			subtitle: "Peace and quiet at last"
+			description: ["Each of the different varieties of Magnum Torch block monster spawns around it. Place one down to finally get some shuteye without the locals kicking down your door."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "20232DC12DE7BAC2"
+			tasks: [{
+				id: "43765CBF511D1F64"
+				type: "item"
+				title: "Any Magnum Torch"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "magnumtorch:diamond_magnum_torch"
+								Count: 1b
+							}
+							{
+								id: "magnumtorch:emerald_magnum_torch"
+								Count: 1b
+							}
+							{
+								id: "magnumtorch:amethyst_magnum_torch"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "073D697510C824AF"
+				type: "xp_levels"
+				xp_levels: 1
+			}]
+		}
+		{
+			title: "Modern Dynamics Pipes"
+			icon: "moderndynamics:item_pipe"
+			x: 3.5d
+			y: -2.0d
+			subtitle: "Ce n'est pas un tapis roulant"
+			description: ["Belts are cool and all, but sometimes you just need to move a thing into another thing.\\n\\nThese pipes are simple and slow, but effective. You'll want an extractor to get stuff out of the inventory you attach them to."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "20691CB9FA1594E1"
+			tasks: [
+				{
+					id: "41350A32812D6FDB"
+					type: "item"
+					item: "moderndynamics:item_pipe"
+				}
+				{
+					id: "1FAC466C164BB286"
+					type: "item"
+					item: "moderndynamics:fluid_pipe"
+				}
+				{
+					id: "1ADDC9573A02EABF"
+					type: "item"
+					item: "moderndynamics:extractor"
+				}
+			]
+			rewards: [{
+				id: "2B95CE8FF81B9361"
+				type: "item"
+				item: "moderndynamics:wrench"
+			}]
+		}
+		{
+			title: "Kitchen Sinks"
+			x: 3.5d
+			y: -1.0d
+			subtitle: "Free drinks"
+			description: ["Sinks have a tradition of being absolutely magic.\\nA kitchen sink filled with water will provide infinite water, which you can pipe out and provide to your various boilers, machines, and water park rides."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "26476630E30A4DB6"
+			tasks: [{
+				id: "6D302169A715E25A"
+				type: "item"
+				title: "Any Adorn Kitchen Sink"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "adorn:oak_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:spruce_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:birch_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:jungle_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:acacia_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:dark_oak_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:mangrove_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:crimson_kitchen_sink"
+								Count: 1b
+							}
+							{
+								id: "adorn:warped_kitchen_sink"
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "4419FF5D168B52AF"
+				type: "item"
+				item: "minecraft:glass_bottle"
+			}]
+		}
+		{
+			x: 4.5d
+			y: 2.5d
+			subtitle: "Won't fill your soul gauge, unfortunately"
+			description: ["Slaughtering animals is inelegant work. We live in an enlightened age, we need tools to match!\\n\\nWhen swung at livestock, Reapers will harvest the animal's drops, but attempt to leave it alive, reverting it to a baby. Higher tier scythes have a better chance of not killing the animal outright."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "3B143BF231304B61"
+			tasks: [{
+				id: "21981FE2315E4A9E"
+				type: "item"
+				title: "Any Reaper"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "reaping:iron_reaping_tool"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "reaping:gold_reaping_tool"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "reaping:diamond_reaping_tool"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "reaping:netherite_reaping_tool"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "1ECDA0CD824D4A64"
+				type: "item"
+				item: "minecraft:leather"
+				count: 3
+			}]
+		}
+		{
+			title: "Simply Swords"
+			x: 2.0d
+			y: -2.0d
+			subtitle: "While you were crafting, I was studying the blade"
+			description: ["Simply swords adds a ton of weapons to your arsenal. Each one features custom animations and attack chains, making combat flow much more smoothly. \\n\\nWorth highlighting here are the various two-handed great weapons and the chakrams, which have a wide reach to their attacks."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "0F1841BF5C079FE8"
+			tasks: [{
+				id: "757DFC8CDA9CB117"
+				type: "item"
+				title: "Any Iron Simply Swords Weapon"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "simplyswords:iron_scythe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_twinblade"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_longsword"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_sai"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_rapier"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_katana"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_glaive"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_warglaive"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_cutlass"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_claymore"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_greathammer"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_greataxe"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+							{
+								id: "simplyswords:iron_chakram"
+								Count: 1b
+								tag: {
+									Damage: 0
+								}
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "3199DC746DEE2AD0"
+				type: "item"
+				item: "croptopia:limeade"
+			}]
+		}
+		{
+			title: "The Twilight Forest"
+			x: -2.0d
+			y: -4.0d
+			subtitle: "Old Growth Mods"
+			description: ["The Twilight Forest is somehow still hanging around, waiting for fearless adventurers to battle their way through.\\n\\nIt still works like it has for years. To get there, surround a 2x2 pool of water with flowers, and toss a diamond in.\\n\\nNothing in the pack requires it, but it's still a fun diversion."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "73E162F0C01D965B"
+			tasks: [{
+				id: "6E9CA2517B4FACC1"
+				type: "dimension"
+				icon: "twilightforest:twilight_portal_miniature_structure"
+				dimension: "twilightforest:twilight_forest"
+			}]
+			rewards: [{
+				id: "3E204FDA6030211F"
+				type: "item"
+				item: {
+					id: "minecraft:potion"
+					Count: 1b
+					tag: {
+						Potion: "minecraft:healing"
+					}
+				}
+			}]
+		}
+		{
+			title: "Hammers"
+			x: 2.0d
+			y: 1.5d
+			subtitle: "And when it arrives? Ahaha, I'll smash it with a hammer!"
+			description: ["Hammers from the wonderfully named Vanilla Hammers mod mines in a 3x3 area. Excellent for carving out your new mountain fastness, or strip mining deep beneath the earth."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "3C054CCF186636C9"
+			tasks: [{
+				id: "6985861E2F42D4E9"
+				type: "item"
+				title: "Any Vanilla Hammer"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "vanilla-hammers:diamond_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:emerald_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:ender_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:fiery_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:golden_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:iron_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:lapis_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:netherite_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:wooden_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:stone_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:slime_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:quartz_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "vanilla-hammers:prismarine_hammer"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "68CE739D81DBBF12"
+				type: "item"
+				item: "minecraft:iron_ingot"
+				count: 3
+			}]
+		}
+		{
+			title: "Building Wands"
+			x: 3.5d
+			y: 2.5d
+			subtitle: "Swish and flick"
+			description: ["Building wands are a full featured tool to assist with block placement. It has multiple modes-- make sure to check the key bindings."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "3B2C6D0907D2A717"
+			tasks: [{
+				id: "7FDA3FAAC66AD5F1"
+				type: "item"
+				title: "Any Building Wand"
+				item: {
+					id: "itemfilters:or"
+					Count: 1b
+					tag: {
+						items: [
+							{
+								id: "wands:stone_wand"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "wands:iron_wand"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "wands:diamond_wand"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+							{
+								id: "wands:netherite_wand"
+								tag: {
+									Damage: 0
+								}
+								Count: 1b
+							}
+						]
+					}
+				}
+			}]
+			rewards: [{
+				id: "5FF2E6EB08910BE0"
+				type: "xp_levels"
+				xp_levels: 1
+			}]
+		}
+		{
+			icon: "xps:block_xp_obelisk"
+			x: 2.0d
+			y: -4.0d
+			subtitle: "No more hiding levels under the mattress"
+			description: ["Dying is a drag. On top of having to go get all that garbage you lug around back, you lose lots of your hard-earned experience!\\n\\nNo more-- with an XP Storage, you can bank your levels for later use. You need an XP Transfer item to make deposits or withdrawals."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "6FA95E848697BB3A"
+			tasks: [
+				{
+					id: "0C83CD4F8248BAED"
+					type: "item"
+					item: "xps:block_xp_obelisk"
+				}
+				{
+					id: "332D3C1A7EE52764"
+					type: "item"
+					item: "xps:xp_remover"
+				}
+			]
+			rewards: [{
+				id: "18353441BD8BAD06"
+				type: "xp_levels"
+				xp_levels: 5
+			}]
+		}
+		{
+			x: -3.0d
+			y: 2.5d
+			subtitle: "The Invisible Hand"
+			description: ["The Market block allows you to barter for some useful items, crops, and critters, without ever having to leave home or set foot in a village.\\n\\nIf you just cannot find a certain farm animal, crop, or magic macguffin, chances are good the market can fix you up."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "1676BCE25FA3E083"
+			tasks: [{
+				id: "5EAE9AE5A477B426"
+				type: "item"
+				item: "farmingforblockheads:market"
+			}]
+			rewards: [{
+				id: "70CF0A3E588BE612"
+				type: "item"
+				item: "minecraft:emerald"
+				count: 2
+			}]
+		}
+		{
+			x: -1.0d
+			y: 2.5d
+			subtitle: "Flax is string."
+			description: ["Flax is a handy crop that can be turned into string when fully grown. Much better than smashing hundreds of spiders."]
+			dependencies: ["2BF52FBBC4A3321E"]
+			id: "15AEADECA895EC50"
+			tasks: [{
+				id: "03735694030212A8"
+				type: "item"
+				item: "supplementaries:flax_seeds"
+			}]
+			rewards: [{
+				id: "33A981D6A71021FD"
+				type: "item"
+				item: "minecraft:string"
+			}]
+		}
+	]
+	quest_links: [ ]
+}

--- a/config/ftbquests/quests/chapters/thriving.snbt
+++ b/config/ftbquests/quests/chapters/thriving.snbt
@@ -129,59 +129,59 @@
 						items: [
 							{
 								id: "minecraft:shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "basicshields:wooden_shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "basicshields:golden_shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "basicshields:diamond_shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "basicshields:netherite_shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "basicshields:bronze_shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "basicshields:steel_shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "twilightforest:knightmetal_shield"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 						]
 					}
@@ -402,31 +402,31 @@
 						items: [
 							{
 								id: "reaping:iron_reaping_tool"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "reaping:gold_reaping_tool"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "reaping:diamond_reaping_tool"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "reaping:netherite_reaping_tool"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 						]
 					}
@@ -458,94 +458,94 @@
 						items: [
 							{
 								id: "simplyswords:iron_scythe"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_twinblade"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_longsword"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_sai"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_rapier"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_katana"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_glaive"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_warglaive"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_cutlass"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_claymore"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_greathammer"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_greataxe"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 							{
 								id: "simplyswords:iron_chakram"
-								Count: 1b
 								tag: {
 									Damage: 0
 								}
+								Count: 1b
 							}
 						]
 					}
@@ -602,94 +602,94 @@
 						items: [
 							{
 								id: "vanilla-hammers:diamond_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:emerald_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:ender_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:fiery_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:golden_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:iron_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:lapis_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:netherite_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:wooden_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:stone_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:slime_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:quartz_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "vanilla-hammers:prismarine_hammer"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 						]
 					}
@@ -721,31 +721,31 @@
 						items: [
 							{
 								id: "wands:stone_wand"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "wands:iron_wand"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "wands:diamond_wand"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 							{
 								id: "wands:netherite_wand"
+								Count: 1b
 								tag: {
 									Damage: 0
 								}
-								Count: 1b
 							}
 						]
 					}

--- a/config/ftbquests/quests/chapters/toms_simple_storage.snbt
+++ b/config/ftbquests/quests/chapters/toms_simple_storage.snbt
@@ -12,6 +12,7 @@
 			title: "Getting organized"
 			x: -1.0d
 			y: 1.5d
+			shape: "pentagon"
 			description: ["Simple Storage is a mod that will probably feel familiar, as it functions a lot like Applied Energistics. However, it's purely low-tech and takes no power, and provides a way to interface with a whole room full of chests at once, including crafting from them. \\n\\nOf course, its powers of automation pale in comparison, so eventually you will want to upgrade! But first, lets figure out how to make this work."]
 			invisible: true
 			id: "00A7B3E6805233FD"


### PR DESCRIPTION
My long national nightmare is over

* Fixed Create quests order and dependencies, so it will ask you to make stuff in the correct order.
* Added the 'Thriving' chapter, which just has little one-off useful things in it. Mining and nethering dims, market blocks, hammers and scythes, that kind of thing.
* Some little polish things here and there.